### PR TITLE
Add Register Component and logic 

### DIFF
--- a/src/pimlify-vue/src/components/RegisterComponent.vue
+++ b/src/pimlify-vue/src/components/RegisterComponent.vue
@@ -55,6 +55,7 @@ import Vue from 'vue';
 import Component from 'vue-class-component';
 import { User } from '../store';
 import firebase from 'firebase';
+import { db } from '../main';
 
 @Component
 export default class RegisterComponent extends Vue {
@@ -78,7 +79,8 @@ export default class RegisterComponent extends Vue {
       firebase
         .auth()
         .createUserWithEmailAndPassword(this.user.email, this.user.password)
-        .then(() => {
+        .then(data => {
+          this.createAdditionalUserData(data.user);
           this.clear();
           this.successAlert = true;
           this.errorAlert = false;
@@ -93,6 +95,20 @@ export default class RegisterComponent extends Vue {
 
   public clear() {
     (this.$refs.form as any).reset();
+  }
+
+  private createAdditionalUserData(firebaseUser: firebase.User | null) {
+    if (!firebaseUser) {
+      return;
+    }
+
+    db
+      .collection('user')
+      .doc(firebaseUser.uid)
+      .set({
+        firstname: this.user.firstname,
+        lastname: this.user.lastname
+      });
   }
 }
 </script>

--- a/src/pimlify-vue/src/components/RegisterComponent.vue
+++ b/src/pimlify-vue/src/components/RegisterComponent.vue
@@ -1,5 +1,6 @@
 <template>
- <v-form ref="form" style='width:50%' v-model="valid">
+<div style='width:50%'>
+ <v-form ref="form" v-model="valid">
     <v-text-field
       v-model="user.firstname"
       :rules="nameRules"
@@ -32,17 +33,35 @@
     </v-btn>
     <v-btn @click="clear">clear</v-btn>
   </v-form>
+  <v-alert
+      :value="successAlert"
+      type="success"
+      transition="scale-transition"
+    >
+      Register successful.
+    </v-alert>
+       <v-alert
+      :value="errorAlert"
+      type="error"
+    >
+      Error in Register Process. Please try again or contact administrator. <br /> 
+      Detailed Message: {{errorMessage}}
+    </v-alert>
+</div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
 import Component from 'vue-class-component';
-import value from '*.json';
 import { User } from '../store';
+import firebase from 'firebase';
 
 @Component
 export default class RegisterComponent extends Vue {
   public user: User = new User();
+  public errorAlert: boolean = false;
+  public successAlert: boolean = false;
+  public errorMessage: string = '';
 
   public emailRules = [
     (v: any) => !!v || 'E-mail is required',
@@ -55,15 +74,24 @@ export default class RegisterComponent extends Vue {
   ];
 
   public submit() {
-    console.log('Submit was clicked');
-
     if ((this.$refs.form as any).validate()) {
-      console.log('Validated' + this.user.email);
+      firebase
+        .auth()
+        .createUserWithEmailAndPassword(this.user.email, this.user.password)
+        .then(() => {
+          this.clear();
+          this.successAlert = true;
+          this.errorAlert = false;
+        })
+        .catch(error => {
+          this.errorMessage = error.message;
+          this.successAlert = false;
+          this.errorAlert = true;
+        });
     }
   }
 
   public clear() {
-    console.log('Clear clicked');
     (this.$refs.form as any).reset();
   }
 }

--- a/src/pimlify-vue/src/components/RegisterComponent.vue
+++ b/src/pimlify-vue/src/components/RegisterComponent.vue
@@ -1,0 +1,14 @@
+<template>
+<b>Register</b>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import Component from 'vue-class-component';
+
+@Component
+export default class RegisterComponent extends Vue {}
+</script>
+
+<style>
+</style>

--- a/src/pimlify-vue/src/components/RegisterComponent.vue
+++ b/src/pimlify-vue/src/components/RegisterComponent.vue
@@ -1,13 +1,72 @@
 <template>
-<b>Register</b>
+ <v-form ref="form" style='width:50%' v-model="valid">
+    <v-text-field
+      v-model="user.firstname"
+      :rules="nameRules"
+      label="First name"
+      required
+    ></v-text-field>
+    <v-text-field
+      v-model="user.lastname"
+      :rules="nameRules"
+      label="Last name"
+      required
+    ></v-text-field>
+    <v-text-field
+      v-model="user.email"
+      :rules="emailRules"
+      label="E-Mail"
+      required
+    ></v-text-field>
+    <v-text-field
+      v-model="user.password"
+      :type="'password'"
+      label="Password"
+      required
+    ></v-text-field>
+      <v-btn
+      :disabled="!valid"
+      @click="submit"
+    >
+      Register
+    </v-btn>
+    <v-btn @click="clear">clear</v-btn>
+  </v-form>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
 import Component from 'vue-class-component';
+import value from '*.json';
+import { User } from '../store';
 
 @Component
-export default class RegisterComponent extends Vue {}
+export default class RegisterComponent extends Vue {
+  public user: User = new User();
+
+  public emailRules = [
+    (v: any) => !!v || 'E-mail is required',
+    (v: any) => /.+@.+/.test(v) || 'E-mail must be valid'
+  ];
+
+  public nameRules = [
+    (v: any) => !!v || 'Name is required',
+    (v: any) => (v && v.length > 3) || 'Name must be more than 3 characters'
+  ];
+
+  public submit() {
+    console.log('Submit was clicked');
+
+    if ((this.$refs.form as any).validate()) {
+      console.log('Validated' + this.user.email);
+    }
+  }
+
+  public clear() {
+    console.log('Clear clicked');
+    (this.$refs.form as any).reset();
+  }
+}
 </script>
 
 <style>

--- a/src/pimlify-vue/src/components/RegisterComponent.vue
+++ b/src/pimlify-vue/src/components/RegisterComponent.vue
@@ -41,7 +41,7 @@
       Register successful.
     </v-alert>
        <v-alert
-      :value="errorAlert"
+      :value="this.errorMessage"
       type="error"
     >
       Error in Register Process. Please try again or contact administrator. <br /> 
@@ -60,7 +60,6 @@ import { db } from '../main';
 @Component
 export default class RegisterComponent extends Vue {
   public user: User = new User();
-  public errorAlert: boolean = false;
   public successAlert: boolean = false;
   public errorMessage: string = '';
 
@@ -83,12 +82,11 @@ export default class RegisterComponent extends Vue {
           this.createAdditionalUserData(data.user);
           this.clear();
           this.successAlert = true;
-          this.errorAlert = false;
+          this.errorMessage = '';
         })
         .catch(error => {
           this.errorMessage = error.message;
           this.successAlert = false;
-          this.errorAlert = true;
         });
     }
   }

--- a/src/pimlify-vue/src/router.ts
+++ b/src/pimlify-vue/src/router.ts
@@ -1,5 +1,7 @@
 import OrderMenu from './components/OrderMenu.vue';
 import RestaurantComponent from './components/RestaurantComponent.vue';
+import RegisterComponent from './components/RegisterComponent.vue';
+
 import VueRouter from 'vue-router';
 
 const routes = [
@@ -12,6 +14,11 @@ const routes = [
     path: '/restaurant',
     component: RestaurantComponent,
     name: 'restaurant'
+  },
+  {
+    path: '/register',
+    component: RegisterComponent,
+    name: 'register'
   }
 ];
 

--- a/src/pimlify-vue/src/store/actions.ts
+++ b/src/pimlify-vue/src/store/actions.ts
@@ -32,7 +32,7 @@ const actions: ActionTree<State, State> = {
     db.collection('restaurant')
       .get()
       .then(querySnapshot => {
-        querySnapshot.forEach(doc =>  {
+        querySnapshot.forEach(doc => {
           const restaurant = doc.data() as Restaurant;
           restaurant.id = doc.id;
           restaurants.push(restaurant);

--- a/src/pimlify-vue/src/store/mutation-types.ts
+++ b/src/pimlify-vue/src/store/mutation-types.ts
@@ -28,3 +28,10 @@ export class Restaurant {
   public name: string = '';
   public location: string = '';
 }
+
+export class User {
+  public firstname: string = '';
+  public lastname: string = '';
+  public email: string = '';
+  public password: string = '';
+}

--- a/src/pimlify-vue/tsconfig.json
+++ b/src/pimlify-vue/tsconfig.json
@@ -1,21 +1,18 @@
 {
-  "include": [
-    "./src/**/*"
-  ],
-  "exclude": [
-    "node_modules"
-  ],
-    "compilerOptions": {
-      // this aligns with Vue's browser support
-      "target": "es5",
-      // this enables stricter inference for data properties on `this`
-      "strict": true,
-      // if using webpack 2+ or rollup, to leverage tree shaking:
-      "module": "commonjs",
-      "allowJs": true,
-      "moduleResolution": "node",
-      "experimentalDecorators": true,
-      "emitDecoratorMetadata": true,
-      "allowSyntheticDefaultImports": true,
-    }
+  "include": ["./src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    // this aligns with Vue's browser support
+    "target": "es5",
+    // this enables stricter inference for data properties on `this`
+    "strict": true,
+    // if using webpack 2+ or rollup, to leverage tree shaking:
+    "module": "commonjs",
+    "allowJs": true,
+    "moduleResolution": "node",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "allowSyntheticDefaultImports": true,
+    "noImplicitAny": false
   }
+}


### PR DESCRIPTION
@Opiskull should the createUserWithEmailAndPassword and createAdditionalUserData handled in the store or directly in the component?

Not sure if this information is needed in any other component since the authentication state should be stored within the firebase extension automatically - and also accessed through the firebase extension. Therefore an implementation in the store seems to be overkill.

Current implementation is in RegisterComponent.vue